### PR TITLE
fix #1: allow setting any Code Mirror option

### DIFF
--- a/src/components/field-sourcecode.vue
+++ b/src/components/field-sourcecode.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <codemirror v-model="value" :options="cmOptions" ref="editor"></codemirror>
+    <codemirror v-model="value" :options="codeMirrorOptions" ref="editor"></codemirror>
   </div>
 </template>
 
@@ -11,37 +11,41 @@ import VueFormGenerator from "vue-form-generator";
 
 import { codemirror } from "vue-codemirror";
 require("codemirror/lib/codemirror.css");
-require("codemirror/theme/eclipse.css");
 
 export default {
   mixins: [VueFormGenerator.abstractField],
   components: {
     codemirror
   },
+  computed: {
+    codeMirrorOptions() {
+      // Allows setting of CodeMirror options, including setting theme
+      // http://codemirror.net/doc/manual.html#config
 
-  data() {
-    return {
-      cmOptions: {
-        // codemirror options
-        taPbSize: 4,
-        mode: "text/x-vue",
-        theme: "eclipse",
-        lineNumbers: true,
-        line: true
+      if (this.schema.hasOwnProperty("codeMirrorOptions")) {
+        // Load theme css, if specified in codeMirrorOptions
+        if (this.schema.codeMirrorOptions.hasOwnProperty("theme")) {
+          require("codemirror/theme/" +
+            this.schema.codeMirrorOptions.theme +
+            ".css");
+        }
+
+        return this.schema.codeMirrorOptions;
+      } else {
+        return {};
       }
-    };
+    }
   },
-
   mounted() {
     setTimeout(() => {
-      if(this.$refs.editor && this.$refs.editor.codemirror)
+      if (this.$refs.editor && this.$refs.editor.codemirror)
         this.$refs.editor.codemirror.refresh();
     }, 1000);
   }
 };
 </script>
-<style>
 
+<style>
 .CodeMirror {
   width: 500px;
   height: 120px;
@@ -50,5 +54,4 @@ export default {
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
   font-size: 80%;
 }
-
 </style>

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1,12 +1,6 @@
 import { storiesOf } from "@storybook/vue";
 
-// Add more stories here to live develop your components
-storiesOf("field-sourcecode", module).add("story as a template", () => {
-  return {
-    data: function() {
-      return {
-        model: {
-          source: `<template>
+const egVueSource = `<template>
   <codemirror v-model="value" :options="cmOptions" ref="editor"></codemirror>
 </template>
 
@@ -20,26 +14,125 @@ export default {
   },
 };
 </script>
+
 <style>
 .CodeMirror {
   width: 500px;
   height: 120px;
 }
 </style>
-`
+`;
+const egJSONSource = `{
+    "glossary": {
+        "title": "example glossary",
+		"GlossDiv": {
+            "title": "S",
+			"GlossList": {
+                "GlossEntry": {
+                    "ID": "SGML",
+					"SortAs": "SGML",
+					"GlossTerm": "Standard Generalized Markup Language",
+					"Acronym": "SGML",
+					"Abbrev": "ISO 8879:1986",
+					"GlossDef": {
+                        "para": "A meta-markup language, used to create markup languages such as DocBook.",
+						"GlossSeeAlso": ["GML", "XML"]
+                    },
+					"GlossSee": "markup"
+                }
+            }
+        }
+    }
+}
+`;
+
+const vfgOutput = `<vue-form-generator :schema="schema" :model="model"></vue-form-generator>`;
+const debugOutput = `
+    <h2>Model</h2>
+    <pre style="white-space: pre-wrap;">{{ model }}</pre>
+
+    <h2>Schema</h2>
+    <pre style="white-space: pre-wrap;">{{ schema }}</pre>`;
+const templateString = `<div>${vfgOutput}${debugOutput}</div>`;
+
+//
+// Add more stories here to live develop your components
+//
+storiesOf("field-sourcecode", module).add("Story as a template", () => {
+  return {
+    data: function() {
+      return {
+        model: {
+          source: egVueSource
         },
         schema: {
           fields: [
             {
               type: "sourcecode",
               label: "source code",
-              model: "source"
+              model: "source",
+              codeMirrorOptions: {
+                mode: "text/x-vue"
+              }
             }
           ]
         }
       };
     },
 
-    template: `<vue-form-generator :schema="schema" :model="model"></vue-form-generator>`
+    template: templateString
+  };
+});
+
+storiesOf("field-sourcecode", module).add("Change mode to JSON", () => {
+  return {
+    data: function() {
+      return {
+        model: {
+          source: egJSONSource
+        },
+        schema: {
+          fields: [
+            {
+              type: "sourcecode",
+              label: "source code",
+              model: "source",
+              codeMirrorOptions: {
+                mode: "application/json"
+              }
+            }
+          ]
+        }
+      };
+    },
+
+    template: templateString
+  };
+});
+
+storiesOf("field-sourcecode", module).add("Use Monokai theme", () => {
+  return {
+    data: function() {
+      return {
+        model: {
+          source: egVueSource
+        },
+        schema: {
+          fields: [
+            {
+              type: "sourcecode",
+              label: "source code",
+              model: "source",
+              codeMirrorOptions: {
+                mode: "text/x-vue",
+                theme: "monokai"
+              }
+            }
+          ]
+        }
+      };
+    },
+
+    template: templateString
   };
 });


### PR DESCRIPTION
Allow setting any code mirror option in the schema, by setting a codeMirrorOptions object. All Code Mirror options now default to Code Mirror defaults. Also add some stories to show the new properties & add some extra output to the stories, so you can see the properties being set.

#1

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/gwenaelp/vfg-field-sourcecode/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Defaults for Code Mirror options now match/use Code Mirror defaults.